### PR TITLE
Updated ViewTransformerManager for using the most accurate ViewTransformer

### DIFF
--- a/reword/src/test/java/dev/b3nedikt/reword/ViewTransformerManagerTest.kt
+++ b/reword/src/test/java/dev/b3nedikt/reword/ViewTransformerManagerTest.kt
@@ -1,6 +1,7 @@
 package dev.b3nedikt.reword
 
 import android.os.Build
+import android.widget.EditText
 import android.widget.TextView
 import androidx.test.core.app.ApplicationProvider
 import com.nhaarman.mockitokotlin2.doReturn
@@ -19,6 +20,17 @@ class ViewTransformerManagerTest {
 
     private lateinit var transformerManager: ViewTransformerManager
 
+    private val transformerTextView = object : ViewTransformer<TextView> {
+        override val viewType = TextView::class.java
+        override val supportedAttributes = emptySet<String>()
+        override fun TextView.transform(attrs: Map<String, Int>) = run { id = TEXT_VIEW_ID }
+    }
+    private val transformerEditText = object : ViewTransformer<EditText> {
+        override val viewType = EditText::class.java
+        override val supportedAttributes = emptySet<String>()
+        override fun EditText.transform(attrs: Map<String, Int>) = run { id = EDIT_TEXT_ID }
+    }
+
     @Before
     fun setUp() {
         transformerManager = ViewTransformerManager()
@@ -36,6 +48,34 @@ class ViewTransformerManagerTest {
 
         val transformedView = transformerManager.transform(textView, mock())
 
-        textView shouldBe  transformedView
+        textView shouldBe transformedView
+    }
+
+    @Test
+    fun shouldApplyCurrentTransformer() {
+        val editText = EditText(ApplicationProvider.getApplicationContext())
+
+        transformerManager.registerTransformer(transformerTextView)
+        transformerManager.registerTransformer(transformerEditText)
+
+        val transformedView = transformerManager.transform(editText, mock())
+
+        transformedView.id shouldBe EDIT_TEXT_ID
+    }
+
+    @Test
+    fun shouldApplyParentTransformer() {
+        val editText = EditText(ApplicationProvider.getApplicationContext())
+
+        transformerManager.registerTransformer(transformerTextView)
+
+        val transformedView = transformerManager.transform(editText, mock())
+
+        transformedView.id shouldBe TEXT_VIEW_ID
+    }
+
+    companion object {
+        const val TEXT_VIEW_ID = 1
+        const val EDIT_TEXT_ID = 2
     }
 }


### PR DESCRIPTION
## Description
Based on the code `viewTransformer.viewType.isInstance(view)`, it finds always the firsts `viewTransformers`, so it means that the order is important and we can't specify `viewTransformers` for some inheritors.

This PR is fixing the problem. Firstly we're trying to find the most specific and accurate `viewTransformers` and if it's impossible, then we're trying to find the parent one.

## Summary of changes
- Changed field `transformers` in `ViewTransformerManager` from `List` to `Map`
- Updated view transformer search function
- Added tests